### PR TITLE
Restore ungrabbed attack mixin storage

### DIFF
--- a/src/main/java/com/v5/mixins/MinecraftMixin.java
+++ b/src/main/java/com/v5/mixins/MinecraftMixin.java
@@ -40,7 +40,7 @@ public class MinecraftMixin {
             )
     )
     private boolean v5$allowAttackWhileUngrabbed(boolean original) {
-        return original || Client.automatedAttackHeld;
+        return original || V5MixinStorage.getBoolean("ungrabbed", false) || Client.automatedAttackHeld;
     }
 
     @Inject(method = "handleKeybinds()V", at = @At("HEAD"))


### PR DESCRIPTION
### Motivation
- Reintroduce the V5 `ungrabbed` flag check into the attack-while-ungrabbed mixin to preserve the original behavior that was unintentionally removed by the previous change while keeping the CTJS automated-attack override.

### Description
- In `src/main/java/com/v5/mixins/MinecraftMixin.java` restore the `V5MixinStorage.getBoolean("ungrabbed", false)` check in `v5$allowAttackWhileUngrabbed`, resulting in `return original || V5MixinStorage.getBoolean("ungrabbed", false) || Client.automatedAttackHeld;`.

### Testing
- Ran `git diff --check` which showed no issues, and attempted `./gradlew test` which failed due to the environment lacking a Java 25 toolchain, so full automated test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd61ffe8c8333a277ecbcd73c2340)